### PR TITLE
Create receivable for pending sales

### DIFF
--- a/src/hooks/useCreateAccountReceivable.ts
+++ b/src/hooks/useCreateAccountReceivable.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { TablesInsert } from '@/integrations/supabase/types';
+import { TablesInsert, Database } from '@/integrations/supabase/types';
 
-type NewAccountReceivable = TablesInsert<'accounts_receivable'>;
+type NewAccountReceivable = TablesInsert<'accounts_receivable'> & {
+  expected_payment_method?: Database['public']['Enums']['payment_method'] | null;
+};
 
 const createAccountReceivable = async (entry: NewAccountReceivable) => {
   const { data, error } = await supabase

--- a/src/hooks/useCreateSale.ts
+++ b/src/hooks/useCreateSale.ts
@@ -1,16 +1,23 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { TablesInsert } from '@/integrations/supabase/types';
+import { TablesInsert, Database } from '@/integrations/supabase/types';
+import { useCreateAccountReceivable } from '@/hooks/useCreateAccountReceivable';
 
 type NewSale = Omit<TablesInsert<'sales'>, 'total_amount'>;
 type NewSaleItem = Omit<TablesInsert<'sale_items'>, 'sale_id'>;
 
+interface FinancialData {
+  due_date: string;
+  expected_payment_method: Database['public']['Enums']['payment_method'];
+}
+
 interface CreateSaleParams {
   saleData: NewSale;
   itemsData: NewSaleItem[];
+  financialData?: FinancialData;
 }
 
-const createSale = async ({ saleData, itemsData }: CreateSaleParams) => {
+const createSale = async ({ saleData, itemsData }: Omit<CreateSaleParams, 'financialData'>) => {
   const total_amount = itemsData.reduce((sum, item) => sum + (item.total_price || 0), 0);
 
   const { data: sale, error: saleError } = await supabase
@@ -46,9 +53,27 @@ const createSale = async ({ saleData, itemsData }: CreateSaleParams) => {
 
 export const useCreateSale = () => {
   const queryClient = useQueryClient();
+  const createAccountReceivable = useCreateAccountReceivable();
 
   return useMutation({
-    mutationFn: createSale,
+    mutationFn: async (params: CreateSaleParams) => {
+      const { financialData, ...rest } = params;
+      const sale = await createSale(rest);
+
+      if (financialData) {
+        await createAccountReceivable.mutateAsync({
+          sale_id: sale.id,
+          amount: sale.total_amount,
+          due_date: financialData.due_date,
+          expected_payment_method: financialData.expected_payment_method,
+          customer_id: sale.customer_id,
+          description: `Recebível da venda ${sale.id}`,
+          status: 'pending',
+        });
+      }
+
+      return sale;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['sales'] });
       // Also invalidate customers if a sale is associated with one, as it might affect their history


### PR DESCRIPTION
## Summary
- extend useCreateSale with financial data and receivable creation
- allow accounts receivable hook to accept expected payment method
- capture due date and payment method in sales form when sale is pending

## Testing
- `npm run lint` *(fails: Unexpected any and other errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897ff5092a8832991ed062759243e2b