### PR TITLE
feat: add accounts receivable renegotiation logs

### DIFF
--- a/src/hooks/useAccountsReceivableLogs.ts
+++ b/src/hooks/useAccountsReceivableLogs.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { Tables } from '@/integrations/supabase/types';
+
+const fetchLogs = async (accountId: string): Promise<Tables<'accounts_receivable_logs'>[]> => {
+  const { data, error } = await supabase
+    .from('accounts_receivable_logs')
+    .select('*')
+    .eq('account_id', accountId)
+    .order('changed_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data || [];
+};
+
+export const useAccountsReceivableLogs = (accountId: string) => {
+  return useQuery({
+    queryKey: ['accountsReceivableLogs', accountId],
+    queryFn: () => fetchLogs(accountId),
+    enabled: !!accountId,
+  });
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -122,6 +122,51 @@ export type Database = {
           },
         ]
       }
+      accounts_receivable_logs: {
+        Row: {
+          id: string
+          account_id: string
+          changed_at: string
+          old_due_date: string | null
+          new_due_date: string | null
+          notes: string | null
+          user_id: string | null
+        }
+        Insert: {
+          id?: string
+          account_id: string
+          changed_at?: string
+          old_due_date?: string | null
+          new_due_date?: string | null
+          notes?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          id?: string
+          account_id?: string
+          changed_at?: string
+          old_due_date?: string | null
+          new_due_date?: string | null
+          notes?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "accounts_receivable_logs_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "accounts_receivable"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "accounts_receivable_logs_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       customers: {
         Row: {
           address: string | null

--- a/supabase/migrations/20250809110000_create_accounts_receivable_logs.sql
+++ b/supabase/migrations/20250809110000_create_accounts_receivable_logs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE public.accounts_receivable_logs (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  account_id UUID NOT NULL REFERENCES public.accounts_receivable(id) ON DELETE CASCADE,
+  changed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  old_due_date DATE,
+  new_due_date DATE,
+  notes TEXT,
+  user_id UUID REFERENCES auth.users(id)
+);
+
+ALTER TABLE public.accounts_receivable_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Permitir tudo em accounts_receivable_logs" ON public.accounts_receivable_logs FOR ALL USING (true);


### PR DESCRIPTION
## Summary
- track due date changes in `accounts_receivable_logs`
- allow renegotiating receivable due dates and viewing history

## Testing
- `npm run lint` *(fails: Unexpected any and require warnings)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980058b040832989cb10017b0a5363