### PR TITLE
feat: add error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/AppSidebar";
 import { Skeleton } from "./components/ui/skeleton";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const Dashboard = lazy(() => import("./pages/Dashboard"));
 const IngredientsPage = lazy(() => import("./pages/IngredientsPage"));
@@ -30,68 +31,70 @@ const NotFound = lazy(() => import("./pages/NotFound"));
 const queryClient = new QueryClient();
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <SidebarProvider>
-          <div className="min-h-screen flex w-full">
-            <AppSidebar />
-            <div className="flex-1">
-              <header
-                id="app-header"
-                className="h-14 border-b flex items-center px-4 lg:px-6 print:hidden"
-              >
-                <SidebarTrigger />
-                <div className="ml-auto">
-                  <h2 className="text-lg font-semibold">Sistema Panisul</h2>
-                </div>
-              </header>
-              <main className="flex-1">
-                <Suspense
-                  fallback={
-                    <div className="p-6">
-                      <Skeleton className="h-24 w-full" />
-                    </div>
-                  }
+  <ErrorBoundary>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <SidebarProvider>
+            <div className="min-h-screen flex w-full">
+              <AppSidebar />
+              <div className="flex-1">
+                <header
+                  id="app-header"
+                  className="h-14 border-b flex items-center px-4 lg:px-6 print:hidden"
                 >
-                  <Routes>
-                    <Route path="/" element={<Dashboard />} />
-                    <Route path="/ingredientes" element={<IngredientsPage />} />
-                    <Route path="/receitas" element={<RecipesPage />} />
-                    <Route path="/producao" element={<ProductionPage />} />
-                    <Route path="/clientes" element={<CustomersPage />} />
-                    <Route
-                      path="/clientes/:id"
-                      element={<CustomerDetailPage />}
-                    />
-                    <Route path="/vendas" element={<SalesPage />} />
-                    <Route path="/compras" element={<PurchasesPage />} />
-                    <Route path="/trocas" element={<ExchangesPage />} />
-                    <Route
-                      path="/contas-pagar"
-                      element={<AccountsPayablePage />}
-                    />
-                    <Route
-                      path="/contas-receber"
-                      element={<AccountsReceivablePage />}
-                    />
-                    <Route
-                      path="/financeiro/contas"
-                      element={<FinancialAccountsPage />}
-                    />
-                    <Route path="/relatorios" element={<ReportsPage />} />
-                    <Route path="*" element={<NotFound />} />
-                  </Routes>
-                </Suspense>
-              </main>
+                  <SidebarTrigger />
+                  <div className="ml-auto">
+                    <h2 className="text-lg font-semibold">Sistema Panisul</h2>
+                  </div>
+                </header>
+                <main className="flex-1">
+                  <Suspense
+                    fallback={
+                      <div className="p-6">
+                        <Skeleton className="h-24 w-full" />
+                      </div>
+                    }
+                  >
+                    <Routes>
+                      <Route path="/" element={<Dashboard />} />
+                      <Route path="/ingredientes" element={<IngredientsPage />} />
+                      <Route path="/receitas" element={<RecipesPage />} />
+                      <Route path="/producao" element={<ProductionPage />} />
+                      <Route path="/clientes" element={<CustomersPage />} />
+                      <Route
+                        path="/clientes/:id"
+                        element={<CustomerDetailPage />}
+                      />
+                      <Route path="/vendas" element={<SalesPage />} />
+                      <Route path="/compras" element={<PurchasesPage />} />
+                      <Route path="/trocas" element={<ExchangesPage />} />
+                      <Route
+                        path="/contas-pagar"
+                        element={<AccountsPayablePage />}
+                      />
+                      <Route
+                        path="/contas-receber"
+                        element={<AccountsReceivablePage />}
+                      />
+                      <Route
+                        path="/financeiro/contas"
+                        element={<FinancialAccountsPage />}
+                      />
+                      <Route path="/relatorios" element={<ReportsPage />} />
+                      <Route path="*" element={<NotFound />} />
+                    </Routes>
+                  </Suspense>
+                </main>
+              </div>
             </div>
-          </div>
-        </SidebarProvider>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+          </SidebarProvider>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </ErrorBoundary>
 );
 
 export default App;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ErrorInfo, type ReactNode } from "react"
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo)
+  }
+
+  handleReload = () => {
+    window.location.reload()
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center p-6 text-center">
+          <h1 className="text-2xl font-semibold mb-2">Algo deu errado</h1>
+          <p className="mb-4">Por favor, tente recarregar a página.</p>
+          <button
+            onClick={this.handleReload}
+            className="rounded bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
+          >
+            Recarregar
+          </button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary


### PR DESCRIPTION
## Summary
- implement `ErrorBoundary` component to catch runtime errors with friendly fallback and reload option
- wrap `App` content with `ErrorBoundary` to handle failures gracefully

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_6897f69a66d08329b301dcb14514f357