### PR TITLE
docs: update dev server port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Para executar este projeto localmente, siga os passos abaixo.
     ```sh
     npm run dev
     ```
-    A aplicação estará disponível em `http://localhost:5173` (ou outra porta indicada no terminal).
+    A aplicação estará disponível em `http://localhost:8080` (ou outra porta indicada no terminal).
 
 4.  **Para build de produção:**
     ```sh


### PR DESCRIPTION
## Summary
- update development server port to 8080 in docs

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68980736c740832984c0b0f4de6be327