### PR TITLE
chore: exclude sentry from bundle

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,11 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      external: ["@sentry/browser"],
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Summary
- avoid bundling `@sentry/browser`

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Unexpected any, react-refresh and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689809f1bc048329a9266eda32ceae48